### PR TITLE
Fix code scanning alert no. 150: Database query built from user-controlled sources

### DIFF
--- a/router/caller/changeName.ts
+++ b/router/caller/changeName.ts
@@ -56,7 +56,7 @@ export default async function ChangeName(req: Request<any>, res: Response<any>) 
 
 	const change = await Caller.updateOne(
 		{ phone: { $eq: req.body.phone }, pinCode: { $eq: req.body.pinCode }, area: { $eq: req.body.area } },
-		{ name: req.body.newName }
+		{ $set: { name: req.body.newName } }
 	);
 	if (change.matchedCount != 1) {
 		res.status(400).send({ message: 'Caller not found', OK: false });


### PR DESCRIPTION
Fixes [https://github.com/ThePiratePhone/ThePiratePhone-Backend/security/code-scanning/150](https://github.com/ThePiratePhone/ThePiratePhone-Backend/security/code-scanning/150)

To fix the problem, we need to ensure that the `newName` field is properly sanitized before being used in the MongoDB query. We can use the `$set` operator to explicitly set the `name` field to the sanitized value, ensuring that it is treated as a literal value.

- Modify the `updateOne` method to use the `$set` operator for updating the `name` field.
- Ensure that the `sanitizeString` function is properly sanitizing the input to prevent any injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
