### PR TITLE
Fix code scanning alert no. 152: Database query built from user-controlled sources

### DIFF
--- a/router/admin/caller/changeName.ts
+++ b/router/admin/caller/changeName.ts
@@ -63,7 +63,7 @@ export default async function ChangeName(req: Request<any>, res: Response<any>) 
 
 	req.body.newName = sanitizeString(req.body.newName);
 
-	const change = await Caller.updateOne({ phone: phone, area: { $eq: req.body.area } }, { name: req.body.newName });
+	const change = await Caller.updateOne({ phone: phone, area: { $eq: req.body.area } }, { name: { $eq: req.body.newName } });
 	if (change.matchedCount != 1) {
 		res.status(400).send({ message: 'Caller not found', OK: false });
 		log('Caller not found from ' + ip, 'WARNING', __filename);


### PR DESCRIPTION
Fixes [https://github.com/ThePiratePhone/ThePiratePhone-Backend/security/code-scanning/152](https://github.com/ThePiratePhone/ThePiratePhone-Backend/security/code-scanning/152)

To fix the problem, we should ensure that the user input is properly sanitized or validated before being used in the database query. Since the `sanitizeString` function's effectiveness is not clear, we should use MongoDB's `$eq` operator to ensure that the user input is interpreted as a literal value and not as a query object.

- Modify the query on line 66 to use the `$eq` operator for the `name` field.
- Ensure that the `sanitizeString` function is still called to remove any unwanted characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
