### PR TITLE
Fix code scanning alert no. 147: Database query built from user-controlled sources

### DIFF
--- a/router/admin/campaign/changePassword.ts
+++ b/router/admin/campaign/changePassword.ts
@@ -10,7 +10,7 @@ export default async function changePasword(req: Request<any>, res: Response<any
 	if (
 		!req.body ||
 		typeof req.body.adminCode != 'string' ||
-		req.body.newAdminCode ||
+		typeof req.body.newAdminCode != 'string' || req.body.newAdminCode.trim() === '' ||
 		!ObjectId.isValid(req.body.area)
 	) {
 		res.status(400).send({ message: 'Missing parameters', OK: false });
@@ -25,7 +25,7 @@ export default async function changePasword(req: Request<any>, res: Response<any
 		return;
 	}
 
-	const output = await Campaign.updateOne({ _id: area._id }, { adminPassword: req.body.newAdminCode });
+	const output = await Campaign.updateOne({ _id: area._id }, { adminPassword: { $eq: req.body.newAdminCode } });
 
 	if (output.modifiedCount == 0) {
 		res.status(404).send({ message: 'Campaign not found', OK: false });


### PR DESCRIPTION
Fixes [https://github.com/ThePiratePhone/ThePiratePhone-Backend/security/code-scanning/147](https://github.com/ThePiratePhone/ThePiratePhone-Backend/security/code-scanning/147)

To fix the problem, we need to ensure that the `req.body.newAdminCode` is properly validated before being used in the database query. We can achieve this by checking that `req.body.newAdminCode` is a string and meets any additional criteria (e.g., length, format) before using it in the query. This will prevent any potential NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
