### PR TITLE
Fix code scanning alert no. 153: Database query built from user-controlled sources

### DIFF
--- a/router/admin/caller/changeCallerPassword.ts
+++ b/router/admin/caller/changeCallerPassword.ts
@@ -52,7 +52,7 @@ export default async function changeCallerPassword(req: Request<any>, res: Respo
 		log(`Invalid phone number from ` + ip, 'WARNING', __filename);
 		return;
 	}
-	const result = await Caller.updateOne({ phone: phone, area: area._id }, { pinCode: req.body.newPassword });
+	const result = await Caller.updateOne({ phone: phone, area: area._id }, { pinCode: { $eq: req.body.newPassword } });
 	if (result.matchedCount != 1) {
 		res.status(404).send({ message: 'Caller not found or same password', OK: false });
 		log(`Caller not found or same password from ${area.name} admin (${ip})`, 'WARNING', __filename);


### PR DESCRIPTION
Fixes [https://github.com/ThePiratePhone/ThePiratePhone-Backend/security/code-scanning/153](https://github.com/ThePiratePhone/ThePiratePhone-Backend/security/code-scanning/153)

To fix the problem, we need to ensure that the user-provided `newPassword` is safely embedded into the query. We can achieve this by using the `$eq` operator to ensure that the value is treated as a literal and not as a query object. This will prevent any potential NoSQL injection attacks.

- Modify the `updateOne` query to use the `$eq` operator for the `pinCode` field.
- Ensure that the `newPassword` is treated as a literal value in the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
